### PR TITLE
Only generate positive integers for money amount

### DIFF
--- a/main.py
+++ b/main.py
@@ -37,11 +37,11 @@ class ATM:
 
 class TestATM(unittest.TestCase):
     @given(
-        _5=strategies.integers(),
-        _10=strategies.integers(),
-        _20=strategies.integers(),
-        _50=strategies.integers(),
-        _100=strategies.integers(),
+        _5=strategies.integers(min_value=0),
+        _10=strategies.integers(min_value=0),
+        _20=strategies.integers(min_value=0),
+        _50=strategies.integers(min_value=0),
+        _100=strategies.integers(min_value=0),
     )
     def test_depositing_money(
             self,
@@ -51,11 +51,8 @@ class TestATM(unittest.TestCase):
             _50: int,
             _100: int,
     ) -> None:
-        assume(_5 >= 0)
-        assume(_10 >= 0)
-        assume(_20 >= 0)
-        assume(_50 >= 0)
-        assume(_100 >= 0)
+        # Assume we pay in more than zero money.
+        assume(_5 + _10 + _20 + _50 + _100 > 0)
         banknotes: MoneyStash = {
             '_5': _5,
             '_10': _10,


### PR DESCRIPTION
This fixes the following bug:
```
; ./run.sh 
Success: no issues found in 1 source file
You can add @seed(16138189585511260552147392360779548295) to this test to reproduce this failure.
E
======================================================================
ERROR: test_depositing_money (__main__.TestATM)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nmoskopp/src/nmoskopp/coding-dojo-python-property-testing/./main.py", line 40, in test_depositing_money
    _5=strategies.integers(),
  File "/home/nmoskopp/src/nmoskopp/coding-dojo-python-property-testing/venv/lib/python3.9/site-packages/hypothesis/core.py", line 1656, in wrapped_test
    raise the_error_hypothesis_found
  File "/home/nmoskopp/src/nmoskopp/coding-dojo-python-property-testing/venv/lib/python3.9/site-packages/hypothesis/internal/healthcheck.py", line 27, in fail_health_check
    raise FailedHealthCheck(message)
hypothesis.errors.FailedHealthCheck: It looks like your strategy is filtering out a lot of data. Health check found 50 filtered examples but only 4 good ones. This will make your tests much slower, and also will probably distort the data generation quite a lot. You should adapt your strategy to filter less. This can also be caused by a low max_leaves parameter in recursive() calls
See https://hypothesis.readthedocs.io/en/latest/healthchecks.html for more information about this. If you want to disable just this health check, add HealthCheck.filter_too_much to the suppress_health_check settings for this test.

----------------------------------------------------------------------
Ran 1 test in 0.173s

FAILED (errors=1)
# exited 0
```