### PR TITLE
Add a simple bug for the Coding Dojo

### DIFF
--- a/main.py
+++ b/main.py
@@ -31,7 +31,7 @@ class ATM:
         self.stash['_5'] += deposited_stash['_5']
         self.stash['_10'] += deposited_stash['_10']
         self.stash['_20'] += deposited_stash['_20']
-        self.stash['_50'] += deposited_stash['_50']
+        self.stash['_50'] += deposited_stash['_5']
         self.stash['_100'] += deposited_stash['_100']
 
 


### PR DESCRIPTION
This bug is a prerequisite for the first task in the `README`.

It leads to this output:

```
; ./run.sh 
Success: no issues found in 1 source file
F
======================================================================
FAIL: test_depositing_money (__main__.TestATM)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nmoskopp/src/nmoskopp/coding-dojo-python-property-testing/./main.py", line 40, in test_depositing_money
    _5=strategies.integers(),
  File "/home/nmoskopp/src/nmoskopp/coding-dojo-python-property-testing/venv/lib/python3.9/site-packages/hypothesis/core.py", line 1656, in wrapped_test
    raise the_error_hypothesis_found
  File "/home/nmoskopp/src/nmoskopp/coding-dojo-python-property-testing/./main.py", line 72, in test_depositing_money
    self.assertEqual(atm.stash['_50'], _50)
AssertionError: 1 != 0
Falsifying example: test_depositing_money(
    # The test always failed when commented parts were varied together.
    self=<__main__.TestATM testMethod=test_depositing_money>,
    _5=1,
    _10=0,  # or any other generated value
    _20=0,  # or any other generated value
    _50=0,  # or any other generated value
    _100=0,  # or any other generated value
)
Explanation:
    These lines were always and only run by failing examples:
        /usr/lib/python3.9/unittest/case.py:822

----------------------------------------------------------------------
Ran 1 test in 12.188s

FAILED (failures=1)
# exited 0
```