### PR TITLE
Add multiple assumes

### DIFF
--- a/main.py
+++ b/main.py
@@ -51,8 +51,12 @@ class TestATM(unittest.TestCase):
             _50: int,
             _100: int,
     ) -> None:
-        # Assume we pay in more than zero money.
-        assume(_5 + _10 + _20 + _50 + _100 > 0)
+        # Assume we have a positive amount of each banknote
+        assume(_5 > 0)
+        assume(_10 > 0)
+        assume(_20 > 0)
+        assume(_50 > 0)
+        assume(_100 > 0)
         banknotes: MoneyStash = {
             '_5': _5,
             '_10': _10,


### PR DESCRIPTION
```
Ran 1 test in 5.278s

FAILED (failures=1)


1 != 2

Expected :2
Actual   :1
<Click to see difference>

Traceback (most recent call last):
  File "/Users/pat/Code/PropTest/src/coding-dojo-python-property-testing/main.py", line 40, in test_depositing_money
    _5=strategies.integers(min_value=0),
  File "/Users/pat/Code/PropTest/src/coding-dojo-python-property-testing/venv/lib/python3.9/site-packages/hypothesis/core.py", line 1656, in wrapped_test
    raise the_error_hypothesis_found
  File "/Users/pat/Code/PropTest/src/coding-dojo-python-property-testing/main.py", line 73, in test_depositing_money
    self.assertEqual(atm.stash['_50'], _50)
AssertionError: 2 != 1
Falsifying example: test_depositing_money(
    # The test always failed when commented parts were varied together.
    self=<main.TestATM testMethod=test_depositing_money>,
    _5=2,
    _10=1,  # or any other generated value
    _20=1,  # or any other generated value
    _50=1,  # or any other generated value
    _100=1,  # or any other generated value
)
Explanation:
    These lines were always and only run by failing examples:
```